### PR TITLE
Revert "indexer: Initialise all members of git_indexer_progress"

### DIFF
--- a/src/libgit2/indexer.c
+++ b/src/libgit2/indexer.c
@@ -921,13 +921,12 @@ int git_indexer_append(git_indexer *idx, const void *data, size_t size, git_inde
 		if (git_vector_init(&idx->deltas, total_objects / 2, NULL) < 0)
 			return -1;
 
-		stats->total_objects = total_objects;
-		stats->indexed_objects = 0;
 		stats->received_objects = 0;
 		stats->local_objects = 0;
 		stats->total_deltas = 0;
 		stats->indexed_deltas = 0;
-		stats->received_bytes = 0;
+		stats->indexed_objects = 0;
+		stats->total_objects = total_objects;
 
 		if ((error = do_progress_callback(idx, stats)) != 0)
 			return error;

--- a/tests/libgit2/network/remote/local.c
+++ b/tests/libgit2/network/remote/local.c
@@ -16,17 +16,6 @@ static git_strarray push_array = {
 	1,
 };
 
-static int push_transfer_progress_cb(unsigned int current, unsigned int total, size_t bytes, void* payload)
-{
-	GIT_UNUSED(current);
-	GIT_UNUSED(total);
-	GIT_UNUSED(payload);
-
-	cl_assert(bytes == 0);
-
-	return 0;
-}
-
 void test_network_remote_local__initialize(void)
 {
 	cl_git_pass(git_repository_init(&repo, "remotelocal/", 0));
@@ -212,7 +201,6 @@ void test_network_remote_local__push_to_bare_remote(void)
 
 	/* Should be able to push to a bare remote */
 	git_remote *localremote;
-	git_push_options opts = GIT_PUSH_OPTIONS_INIT;
 
 	/* Get some commits */
 	connect_to_local_repository(cl_fixture("testrepo.git"));
@@ -230,8 +218,7 @@ void test_network_remote_local__push_to_bare_remote(void)
 	cl_git_pass(git_remote_connect(localremote, GIT_DIRECTION_PUSH, NULL, NULL, NULL));
 
 	/* Try to push */
-	opts.callbacks.push_transfer_progress = push_transfer_progress_cb;
-	cl_git_pass(git_remote_upload(localremote, &push_array, &opts));
+	cl_git_pass(git_remote_upload(localremote, &push_array, NULL));
 
 	/* Clean up */
 	git_remote_free(localremote);


### PR DESCRIPTION
Reverts mathworks/libgit2#14

Test failures on Windows:
https://github.com/libgit2/libgit2/commit/81eecc342b3580e9b05e501c8ee75c7e2e0dca1a